### PR TITLE
examples: add basic example

### DIFF
--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/hybridgroup/wasmtime"
+)
+
+func main() {
+	// Almost all operations in wasmtime require a contextual `store`
+	// argument to share, so create that first
+	store := wasmtime.NewStore(wasmtime.NewEngine())
+
+	// Compiling modules requires WebAssembly binary input, but the wasmtime
+	// package also supports converting the WebAssembly text format to the
+	// binary format.
+	wasm, err := wasmtime.Wat2Wasm(`
+      (module
+        (import "" "hello" (func $hello))
+        (func (export "run")
+          (call $hello))
+      )
+    `)
+	check(err)
+
+	// Once we have our binary `wasm` we can compile that into a `*Module`
+	// which represents compiled JIT code.
+	module, err := wasmtime.NewModule(store.Engine, wasm)
+	check(err)
+
+	// Our `hello.wat` file imports one item, so we create that function
+	// here.
+	item := wasmtime.WrapFunc(store, func() {
+		fmt.Println("Hello from Go!")
+	})
+
+	// Next up we instantiate a module which is where we link in all our
+	// imports. We've got one import so we pass that in here.
+	instance, err := wasmtime.NewInstance(store, module, []wasmtime.AsExtern{item})
+	check(err)
+
+	// After we've instantiated we can lookup our `run` function and call
+	// it.
+	run := instance.GetFunc(store, "run")
+	if run == nil {
+		panic("not a function")
+	}
+	_, err = run.Call(store)
+	check(err)
+}
+
+func check(e error) {
+	if e != nil {
+		panic(e)
+	}
+}


### PR DESCRIPTION
This PR adds a basic example to serve as reference target for initial implementation: when this compiles/runs, a minimal working proof of concept has probably been achieved.